### PR TITLE
Fixed xmfhtmltok and skills with index > 57

### DIFF
--- a/src/common/graymul.h
+++ b/src/common/graymul.h
@@ -1725,7 +1725,7 @@ enum SKILL_TYPE	// List of skill numbers (things that can be done at a given tim
 	SKILL_IMBUING,
 	SKILL_THROWING,
 	
-	SKILL_QTY,
+	SKILL_QTY = 99,
 
 	// Actions a npc will perform. (no need to track skill level for these)
 	NPCACT_FOLLOW_TARG = 100,	// 100 = following a char.

--- a/src/graysvr/CClientDialog.cpp
+++ b/src/graysvr/CClientDialog.cpp
@@ -456,6 +456,23 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
 			m_iControls++;
 			return true;
 		}
+		case GUMPCTL_XMFHTMLTOK: // 9 = x y width height has_background has_scrollbar color cliloc_id @args
+		{
+			GET_RELATIVE(x, m_iOriginX);
+			GET_RELATIVE(y, m_iOriginY);
+			GET_ABSOLUTE(sX);
+			GET_ABSOLUTE(sY);
+			GET_ABSOLUTE(hasBack);
+			GET_ABSOLUTE(canScroll);
+			GET_ABSOLUTE(color);
+			GET_ABSOLUTE(cliloc);
+			SKIP_ALL(pszArgs);
+
+			m_sControls[m_iControls].Format("xmfhtmltok %d %d %d %d %d %d %d %d %s", x, y, sX, sY, hasBack, canScroll, color, cliloc, *pszArgs ? pszArgs : "");
+
+			m_iControls++;
+			return true;
+		}
 		default:
 			break;
 	}


### PR DESCRIPTION
Fixed xmfhtmltok not working and sphere crashing if using custom skils with index > 57.