### PR TITLE
Various fixes to ships and buy from vendor procedure.

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -2865,3 +2865,9 @@ Fixed: Some skills not calling skillgain when action difficulty > skill value, m
 
 16-02-2016, Coruja
 Changed: Improved Sphere main timestamp engine.
+
+16-02-2016, Nolok
+Fixed: Ships moving but not updating the multi part on Enhanced Client with smooth sailing disabled.
+Changed: Removed useless screen updates when smooth sailing is on, making sailing more fluid.
+Fixed: Price of items sold by the vendor swapped on Enhanced Client.
+Changed: Removed useless packets sent when opening vendor sell gump on Enhanced Client.

--- a/src/graysvr/CClientEvent.cpp
+++ b/src/graysvr/CClientEvent.cpp
@@ -1290,26 +1290,26 @@ void CClient::Event_VendorSell(CChar* pVendor, const VendorItem* items, size_t i
 			amount = pItem->GetAmount();
 		}
 
-		INT64 iPrice = (INT64)pItemSell->GetVendorPrice(iConvertFactor) * amount;
+		LONG lPrice = pItemSell->GetVendorPrice(iConvertFactor) * amount;
 
 
 		if (( IsTrigUsed(TRIGGER_SELL) ) || ( IsTrigUsed(TRIGGER_ITEMSELL) ))
 		{
-			CScriptTriggerArgs Args( amount, iPrice, pVendor );
+			CScriptTriggerArgs Args( amount, lPrice, pVendor );
 			if ( pItem->OnTrigger( ITRIG_Sell, this->GetChar(), &Args ) == TRIGRET_RET_TRUE )
 				continue;
 		}
 
 		// Can vendor afford this ?
-		if ( iPrice > pBank->m_itEqBankBox.m_Check_Amount )
+		if ( lPrice > pBank->m_itEqBankBox.m_Check_Amount )
 		{
 			fShortfall = true;
 			break;
 		}
-		pBank->m_itEqBankBox.m_Check_Amount -= static_cast<unsigned long>(iPrice);
+		pBank->m_itEqBankBox.m_Check_Amount -= static_cast<unsigned long>(lPrice);
 
 		// give them the appropriate amount of gold.
-		iGold += static_cast<int>(iPrice);
+		iGold += static_cast<int>(lPrice);
 
 		// Take the items from player.
 		// Put items in vendor inventory.

--- a/src/graysvr/CClientMsg.cpp
+++ b/src/graysvr/CClientMsg.cpp
@@ -2411,24 +2411,18 @@ int CClient::addShopItems(CChar * pVendor, LAYER_TYPE layer, bool bReal)
 	if ( bReal )
 	{
 		addContents(pContainer, false, false, true, false);
-		for (const CItem* item = pContainer->GetContentTail(); item != NULL && count < MAX_ITEMS_CONT; item = item->GetPrev())
+		for (const CItem* item = pContainer->GetContentHead(); item != NULL && count < MAX_ITEMS_CONT; item = item->GetNext())
 		{
 			addAOSTooltip(item, false, true);
 			count++;
 		}
-		if (GetNetState()->isClientSA())
-		{
-			PacketVendorBuyList* cmd = new PacketVendorBuyList();
-			count = cmd->fillContainer(pContainer, pVendor->NPC_GetVendorMarkup(m_pChar), count);
-			cmd->push(this);
-		}
 	}
 
-	if (!GetNetState()->isClientSA())
+	if ( (bReal && GetNetState()->isClientSA()) || !GetNetState()->isClientSA() )
 	{
 		int iConvertFactor = pVendor->NPC_GetVendorMarkup(m_pChar );
 		PacketVendorBuyList* cmd = new PacketVendorBuyList();
-		count = cmd->fillContainer(pContainer, iConvertFactor, bReal? MAX_ITEMS_CONT : 0);
+		count = cmd->fillContainer(pContainer, iConvertFactor, GetNetState()->isClientSA(), bReal? MAX_ITEMS_CONT : 0);
 		cmd->push(this);
 	}
 
@@ -3588,7 +3582,6 @@ void CClient::addAOSTooltip( const CObjBase * pObj, bool bRequested, bool bShop 
 	{
 		if (bShop && GetNetState()->isClientSA())
 		{
-			new PacketPropertyListVersion(this, pObj, propertyList->getVersion());
 			new PacketPropertyList(this, propertyList);
 		}
 		else

--- a/src/graysvr/CItemShip.cpp
+++ b/src/graysvr/CItemShip.cpp
@@ -142,85 +142,81 @@ size_t CItemShip::Ship_ListObjs( CObjBase ** ppObjList )
 		ppObjList[iCount++] = pChar;
 	}
 
-	CWorldSearch AreaItem( GetTopPoint(), iMaxDist );
-	AreaItem.SetSearchSquare( true );
-	while ( iCount < MAX_MULTI_LIST_OBJS )
+CWorldSearch AreaItem(GetTopPoint(), iMaxDist);
+AreaItem.SetSearchSquare(true);
+while (iCount < MAX_MULTI_LIST_OBJS)
+{
+	CItem * pItem = AreaItem.GetItem();
+	if (pItem == NULL)
+		break;
+	if (pItem == this)	// already listed.
+		continue;
+	if (!Multi_IsPartOf(pItem))
 	{
-		CItem * pItem = AreaItem.GetItem();
-		if ( pItem == NULL )
-			break;
-		if ( pItem == this )	// already listed.
+		if (!m_pRegion->IsInside2d(pItem->GetTopPoint()))
 			continue;
-		if ( ! Multi_IsPartOf( pItem ))
-		{
-			if ( ! m_pRegion->IsInside2d( pItem->GetTopPoint()))
-				continue;
 
-			//I guess we can allow items to be locked on the ships and still move... but disallow attr_static from moving
-			//if ( ! pItem->IsMovable() && !pItem->IsType(IT_CORPSE))
-			if ( IsAttr(ATTR_STATIC) )
-				continue;
+		//I guess we can allow items to be locked on the ships and still move... but disallow attr_static from moving
+		//if ( ! pItem->IsMovable() && !pItem->IsType(IT_CORPSE))
+		if (IsAttr(ATTR_STATIC))
+			continue;
 
-			int zdiff = pItem->GetTopZ() - iShipHeight;
-			if ( zdiff < -2 || zdiff > PLAYER_HEIGHT )
-				continue;
-		}
-		ppObjList[iCount++] = pItem;
+		int zdiff = pItem->GetTopZ() - iShipHeight;
+		if (zdiff < -2 || zdiff > PLAYER_HEIGHT)
+			continue;
 	}
-	return( iCount );
+	ppObjList[iCount++] = pItem;
+}
+return(iCount);
 }
 
-bool CItemShip::Ship_MoveDelta( CPointBase pdelta )
+bool CItemShip::Ship_MoveDelta(CPointBase pdelta)
 {
 	ADDTOCALLSTACK("CItemShip::Ship_MoveDelta");
 	// Move the ship one space in some direction.
 
-	ASSERT( m_pRegion->m_iLinkedSectors );
+	ASSERT(m_pRegion->m_iLinkedSectors);
 
 	int znew = GetTopZ() + pdelta.m_z;
-	if ( pdelta.m_z > 0 )
+	if (pdelta.m_z > 0)
 	{
-		if ( znew >= (UO_SIZE_Z - PLAYER_HEIGHT )-1 )
-			return( false );
+		if (znew >= (UO_SIZE_Z - PLAYER_HEIGHT) - 1)
+			return(false);
 	}
-	else if ( pdelta.m_z < 0 )
+	else if (pdelta.m_z < 0)
 	{
-		if ( znew <= (UO_SIZE_MIN_Z + 3 ))
-			return( false );
+		if (znew <= (UO_SIZE_MIN_Z + 3))
+			return(false);
 	}
 
 	// Move the ship and everything on the deck
-	CObjBase * ppObjs[MAX_MULTI_LIST_OBJS+1];
-	size_t iCount = Ship_ListObjs( ppObjs );
+	CObjBase * ppObjs[MAX_MULTI_LIST_OBJS + 1];
+	size_t iCount = Ship_ListObjs(ppObjs);
 
-	for ( size_t i = 0; i < iCount; i++ )
+	for (size_t i = 0; i < iCount; i++)
 	{
 		CObjBase * pObj = ppObjs[i];
 		if (!pObj) continue;
 		CPointMap pt = pObj->GetTopPoint();
-		CPointMap ptOld(pt);
-
 		pt += pdelta;
-		pt.m_map = pObj->GetTopPoint().m_map;
-		if ( ! pt.IsValidPoint())  // boat goes out of bounds !
+
+		if (!pt.IsValidPoint())  // boat goes out of bounds !
 		{
-			DEBUG_ERR(( "Ship uid=0%lx out of bounds\n", (DWORD) GetUID()));
+			DEBUG_ERR(("Ship uid=0%lx out of bounds\n", (DWORD)GetUID()));
 			continue;
 		}
-
 		pObj->MoveTo(pt);
-
 	}
 
 	ClientIterator it;
 	for (CClient* pClient = it.next(); pClient != NULL; pClient = it.next())
 	{
 		CChar * tMe = pClient->GetChar();
-		if ( tMe == NULL )
+		if (tMe == NULL)
 			continue;
 
 		BYTE tViewDist = static_cast<unsigned char>(tMe->GetSight());
-		for ( size_t i = 0; i < iCount; i++ )
+		for (size_t i = 0; i < iCount; i++)
 		{
 			CObjBase * pObj = ppObjs[i];
 			if (!pObj) continue; //no object anymore? skip!
@@ -231,7 +227,7 @@ bool CItemShip::Ship_MoveDelta( CPointBase pdelta )
 			//Remove objects that just moved out of sight
 			if ((tMe->GetTopPoint().GetDistSight(pt) >= tViewDist) && (tMe->GetTopPoint().GetDistSight(ptOld) < tViewDist))
 			{
-				pClient->addObjectRemove( pObj );
+				pClient->addObjectRemove(pObj);
 				continue; //no need to keep going. skip!
 			}
 
@@ -239,39 +235,42 @@ bool CItemShip::Ship_MoveDelta( CPointBase pdelta )
 			{
 				if (pObj == this) //This is the ship (usually the first item in the list)
 				{
-					if ((pClient->GetNetState()->isClientVersion(MINCLIVER_HS) || pClient->GetNetState()->isClientSA()) && !IsSetOF(OF_NoSmoothSailing))
+					if (pClient->GetNetState()->isClientVersion(MINCLIVER_HS) || pClient->GetNetState()->isClientSA())
 					{
-						CPointMap ptdir = GetTopPoint();
-						ptdir += pdelta;
-
-						new PacketMoveShip(pClient, this, ppObjs, iCount, m_itShip.m_DirMove, m_itShip.m_DirFace, Multi_GetDef()->m_SpeedMode);
-
-						//Client is on Ship
-						if (tMe->GetRegion()->GetResourceID().GetObjUID() == GetUID())
+						if (!IsSetOF(OF_NoSmoothSailing))
 						{
-							pt = tMe->GetTopPoint();
-							pt -= pdelta;
-							pClient->addPlayerSeeShip( pt );
-							if (pClient->GetNetState()->isClientSA())
-								pClient->addPlayerUpdate();
-							break; //skip to next client
+							new PacketMoveShip(pClient, this, ppObjs, iCount, m_itShip.m_DirMove, m_itShip.m_DirFace, Multi_GetDef()->m_SpeedMode);
+
+							//If client is on Ship
+							if (tMe->GetRegion()->GetResourceID().GetObjUID() == GetUID())
+							{
+								pClient->addPlayerSeeShip(tMe->GetTopPoint());
+								break; //skip to next client
+							}
 						}
+						else if (pClient->GetNetState()->isClientSA())
+							pClient->addObjectRemove(pObj);	//it will be added again in the if clause below
 					}
 				}
 				if (pObj->IsItem())
 				{
-					CItem *pItem = dynamic_cast <CItem *>(pObj);
-					if ((tMe->GetTopPoint().GetDistSight(pt) < tViewDist) && ((tMe->GetTopPoint().GetDistSight(ptOld) >= tViewDist) || !(pClient->GetNetState()->isClientVersion(MINCLIVER_HS) || pClient->GetNetState()->isClientSA()) || IsSetOF(OF_NoSmoothSailing)))
+					if ((tMe->GetTopPoint().GetDistSight(pt) < tViewDist)
+						&& ( (tMe->GetTopPoint().GetDistSight(ptOld) >= tViewDist) || !(pClient->GetNetState()->isClientVersion(MINCLIVER_HS) || pClient->GetNetState()->isClientSA()) || IsSetOF(OF_NoSmoothSailing) ))
+					{
+						CItem *pItem = dynamic_cast <CItem *>(pObj);
 						pClient->addItem(pItem);
+					}
+						
 				}
 				else
 				{
 					CChar *pChar = dynamic_cast <CChar *>(pObj);
 					if (pClient == pChar->GetClient())
 						pClient->addPlayerView( ptOld );
-					else if ((tMe->GetTopPoint().GetDistSight(pt) <= tViewDist) && ((tMe->GetTopPoint().GetDistSight(ptOld) > tViewDist) || !(pClient->GetNetState()->isClientVersion(MINCLIVER_HS) || pClient->GetNetState()->isClientSA()) || IsSetOF(OF_NoSmoothSailing)))
+					else if ((tMe->GetTopPoint().GetDistSight(pt) <= tViewDist)
+						&& ( (tMe->GetTopPoint().GetDistSight(ptOld) > tViewDist) || !(pClient->GetNetState()->isClientVersion(MINCLIVER_HS) || pClient->GetNetState()->isClientSA()) || IsSetOF(OF_NoSmoothSailing) ))
 					{
-						if ((pt.GetDist(ptOld) > 1) && (pClient->GetNetState()->isClientLessVersion(MINCLIVER_HS)) && (pChar->GetTopPoint().GetDistSight(ptOld) < tViewDist))
+						if ( (pt.GetDist(ptOld) > 1) && (pClient->GetNetState()->isClientLessVersion(MINCLIVER_HS)) && (pChar->GetTopPoint().GetDistSight(ptOld) < tViewDist) )
 							pClient->addCharMove( pChar );
 						else
 						{

--- a/src/graysvr/CItemShip.cpp
+++ b/src/graysvr/CItemShip.cpp
@@ -142,32 +142,32 @@ size_t CItemShip::Ship_ListObjs( CObjBase ** ppObjList )
 		ppObjList[iCount++] = pChar;
 	}
 
-CWorldSearch AreaItem(GetTopPoint(), iMaxDist);
-AreaItem.SetSearchSquare(true);
-while (iCount < MAX_MULTI_LIST_OBJS)
-{
-	CItem * pItem = AreaItem.GetItem();
-	if (pItem == NULL)
-		break;
-	if (pItem == this)	// already listed.
-		continue;
-	if (!Multi_IsPartOf(pItem))
+	CWorldSearch AreaItem(GetTopPoint(), iMaxDist);
+	AreaItem.SetSearchSquare(true);
+	while (iCount < MAX_MULTI_LIST_OBJS)
 	{
-		if (!m_pRegion->IsInside2d(pItem->GetTopPoint()))
+		CItem * pItem = AreaItem.GetItem();
+		if (pItem == NULL)
+			break;
+		if (pItem == this)	// already listed.
 			continue;
-
-		//I guess we can allow items to be locked on the ships and still move... but disallow attr_static from moving
-		//if ( ! pItem->IsMovable() && !pItem->IsType(IT_CORPSE))
-		if (IsAttr(ATTR_STATIC))
-			continue;
-
-		int zdiff = pItem->GetTopZ() - iShipHeight;
-		if (zdiff < -2 || zdiff > PLAYER_HEIGHT)
-			continue;
+		if (!Multi_IsPartOf(pItem))
+		{
+			if (!m_pRegion->IsInside2d(pItem->GetTopPoint()))
+				continue;
+	
+			//I guess we can allow items to be locked on the ships and still move... but disallow attr_static from moving
+			//if ( ! pItem->IsMovable() && !pItem->IsType(IT_CORPSE))
+			if (IsAttr(ATTR_STATIC))
+				continue;
+	
+			int zdiff = pItem->GetTopZ() - iShipHeight;
+			if (zdiff < -2 || zdiff > PLAYER_HEIGHT)
+				continue;
+		}
+		ppObjList[iCount++] = pItem;
 	}
-	ppObjList[iCount++] = pItem;
-}
-return(iCount);
+	return(iCount);
 }
 
 bool CItemShip::Ship_MoveDelta(CPointBase pdelta)

--- a/src/graysvr/CItemVend.cpp
+++ b/src/graysvr/CItemVend.cpp
@@ -166,7 +166,7 @@ LONG CItemVendable::GetVendorPrice( int iConvertFactor )
 	//    0 = base price
 	// +100 = increase price by 100% (vendor selling to player?)
 
-	INT64 lPrice = m_price;
+	LONG lPrice = m_price;
 	if ( lPrice <= 0 )	// set on player vendor.
 	{
 		if ( lPrice == 0 )	// set a new randomized price for the item
@@ -184,7 +184,7 @@ LONG CItemVendable::GetVendorPrice( int iConvertFactor )
 				pItemDef = Item_GetDef();
 			}
 			lPrice = pItemDef->GetMakeValue(GetQuality());
-			m_price = static_cast<long>(-lPrice);
+			m_price = -lPrice;
 		}
 		else
 		{
@@ -198,7 +198,7 @@ LONG CItemVendable::GetVendorPrice( int iConvertFactor )
 	else if (lPrice <= 0)
 		return 0;
 	
-	return static_cast<long>(lPrice);
+	return lPrice;
 }
 
 bool CItemVendable::IsValidSaleItem( bool fBuyFromVendor ) const

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -2073,7 +2073,7 @@ PacketVendorBuyList::PacketVendorBuyList(void) : PacketSend(XCMD_VendOpenBuy, 8,
 {
 }
 
-int PacketVendorBuyList::fillContainer(const CItemContainer* container, int convertFactor, size_t maxItems)
+int PacketVendorBuyList::fillContainer(const CItemContainer* container, int convertFactor, bool bClientSA, size_t maxItems)
 {
 	ADDTOCALLSTACK("PacketVendorBuyList::fillContainer");
 
@@ -2086,7 +2086,13 @@ int PacketVendorBuyList::fillContainer(const CItemContainer* container, int conv
 	skip(1);
 	size_t count(0);
 
-	for (CItem* item = container->GetContentTail(); item != NULL && count < maxItems; item = item->GetPrev())
+	CItem* item;
+	if (bClientSA)
+		item = container->GetContentHead();
+	else
+		item = container->GetContentTail();
+
+	while (item != NULL && count < maxItems)
 	{
 		if (item->GetAmount() == 0)
 			continue;
@@ -2095,7 +2101,7 @@ int PacketVendorBuyList::fillContainer(const CItemContainer* container, int conv
 		if (venditem == NULL)
 			continue;
 
-		long price = venditem->GetVendorPrice(convertFactor);
+		LONG price = venditem->GetVendorPrice(convertFactor);
 		if (price == 0)
 		{
 			venditem->Item_GetDef()->ResetMakeValue();
@@ -2118,6 +2124,10 @@ int PacketVendorBuyList::fillContainer(const CItemContainer* container, int conv
 		writeByte(static_cast<BYTE>(len));
 		writeStringFixedASCII(name, len);
 
+		if (bClientSA)
+			item = item->GetNext();
+		else
+			item = item->GetPrev();
 		count++;
 	}
 

--- a/src/network/send.h
+++ b/src/network/send.h
@@ -698,7 +698,7 @@ class PacketVendorBuyList : public PacketSend
 {
 public:
 	PacketVendorBuyList(void);
-	int fillContainer(const CItemContainer* container, int convertFactor, size_t maxItems = 115);
+	int fillContainer(const CItemContainer* container, int convertFactor, bool bClientSA, size_t maxItems = 115);
 };
 
 /***************************************************************************


### PR DESCRIPTION
Fixed: Ships moving but not updating the multi part on Enhanced Client with smooth sailing disabled.
Changed: Removed useless screen updates when smooth sailing is on, making sailing more fluid.
Changed: Removed declarations and calculations on unused variables in the sailing engine.
Fixed: Price of items sold by the vendor swapped on Enhanced Client.
Changed: Removed unnecessary casts and changed variable type from INT64 to LONG in CItemVendable::GetVendorPrice and CClient::Event_VendorSell.
Changed: Removed useless packets sent when opening vendor sell gump on Enhanced Client.