### PR TITLE
Made SpawnItem readable under @Create and update tooltip when AddObj or DelObj to a spawnitem.

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -2871,3 +2871,7 @@ Fixed: Ships moving but not updating the multi part on Enhanced Client with smoo
 Changed: Removed useless screen updates when smooth sailing is on, making sailing more fluid.
 Fixed: Price of items sold by the vendor swapped on Enhanced Client.
 Changed: Removed useless packets sent when opening vendor sell gump on Enhanced Client.
+
+17-02-2016, Nolok
+Fixed #2576: SpawnItem value is now readable under @Create trigger.
+Changed: When a spawn item generates a new object, it updates its tooltip in order to view updated data.

--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -2874,4 +2874,3 @@ Changed: Removed useless packets sent when opening vendor sell gump on Enhanced 
 
 17-02-2016, Nolok
 Fixed #2576: SpawnItem value is now readable under @Create trigger.
-Changed: When a spawn item generates a new object, it updates its tooltip in order to view updated data.

--- a/src/graysvr/CItemSpawn.cpp
+++ b/src/graysvr/CItemSpawn.cpp
@@ -183,7 +183,6 @@ void CItemSpawn::GenerateChar(CResourceDef *pDef)
 	pChar->NPC_LoadScript(true);
 	pChar->StatFlag_Set(STATF_Spawned);
 	pChar->MoveTo(pt);
-	pChar->NPC_CreateTrigger();		// removed from NPC_LoadScript() and triggered after char placement
 
 	// Check if the NPC can spawn in this region
 	CRegionBase *pRegion = GetTopPoint().GetRegion(REGION_TYPE_AREA);
@@ -194,6 +193,7 @@ void CItemSpawn::GenerateChar(CResourceDef *pDef)
 	}
 
 	AddObj(pChar->GetUID());
+	pChar->NPC_CreateTrigger();		// removed from NPC_LoadScript() and triggered after char placement and attachment to the spawnitem
 	pChar->Update();
 
 	size_t iCount = GetTopSector()->GetCharComplexity();
@@ -233,6 +233,7 @@ void CItemSpawn::DelObj(CGrayUID uid)
 			ResendTooltip();
 		break;
 	}
+	ResendTooltip();
 }
 
 void CItemSpawn::AddObj(CGrayUID uid)
@@ -289,6 +290,7 @@ void CItemSpawn::AddObj(CGrayUID uid)
 			break;
 		}
 	}
+	ResendTooltip();
 }
 
 void CItemSpawn::OnTick(bool fExec)

--- a/src/graysvr/CItemSpawn.cpp
+++ b/src/graysvr/CItemSpawn.cpp
@@ -233,7 +233,6 @@ void CItemSpawn::DelObj(CGrayUID uid)
 			ResendTooltip();
 		break;
 	}
-	ResendTooltip();
 }
 
 void CItemSpawn::AddObj(CGrayUID uid)
@@ -290,7 +289,6 @@ void CItemSpawn::AddObj(CGrayUID uid)
 			break;
 		}
 	}
-	ResendTooltip();
 }
 
 void CItemSpawn::OnTick(bool fExec)


### PR DESCRIPTION
Fixed #2576: SpawnItem value is now readable under @Create trigger.
Changed: When a spawn item generates a new object, it updates its tooltip in order to view updated data.