### PR TITLE
Fixed a bug with values RETURNed by triggers fired from scripts with TRIGGER keyword.

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -2917,3 +2917,8 @@ Fixed: Enhanced clients not placing items on correct container GRID slot when us
 23-02-2015, Coruja
 Fixed: Some clients not parsing correctly the last number/letter of client version.
 Changed: Function REPORTEDCLIVER.1 got removed, it's no longer needed because now REPORTEDCLIVER will return the full client version by default.
+Fixed: Spawn items resetting COUNT and AMOUNT values to 0 on server restart.
+
+24-02-2015, Nolok
+Fixed: In certain situations returning 0 inside a custom trigger caused TRIGGER keyword to return 2. Also, potentially every value
+	between 0-8 could interfere with some internal check. Now any value < 100 can be safely returned and readed.

--- a/src/common/CScriptObj.h
+++ b/src/common/CScriptObj.h
@@ -19,11 +19,12 @@
 		TRIGRUN_SINGLE_FALSE	// ignore just this line or blocked segment.
 	};
 
-	enum TRIGRET_TYPE	// trigger script returns.
+	enum TRIGRET_TYPE		// trigger script returns.
 	{
-		TRIGRET_RET_FALSE = 0,	// default return. (script might not have been handled)
-		TRIGRET_RET_TRUE = 1,
-		TRIGRET_RET_DEFAULT,	// we just came to the end of the script.
+		// Starting from 100 will allow scripts to use safely return values < than 100.
+		TRIGRET_RET_FALSE = 100,	// Default return. (script might not have been handled)
+		TRIGRET_RET_TRUE,			// Script successifully returned a value.
+		TRIGRET_RET_DEFAULT,		// We just came to the end of the script.
 		TRIGRET_ENDIF,
 		TRIGRET_ELSE,
 		TRIGRET_ELSEIF,

--- a/src/graysvr/CItemSpawn.cpp
+++ b/src/graysvr/CItemSpawn.cpp
@@ -133,7 +133,7 @@ void CItemSpawn::GenerateItem(CResourceDef *pDef)
 	if ( pItem == NULL )
 		return;
 
-	WORD iAmountPile = static_cast<WORD>(minimum(USHRT_MAX,m_itSpawnItem.m_pile));
+	WORD iAmountPile = minimum(USHRT_MAX,m_itSpawnItem.m_pile);
 	if ( iAmountPile > 1 )
 	{
 		CItemBase *pItemDef = pItem->Item_GetDef();
@@ -200,7 +200,7 @@ void CItemSpawn::DelObj(CGrayUID uid)
 		return;
 
 	BYTE iMax = GetCount();
-	for ( unsigned char i = 0; i < iMax; i++ )
+	for ( BYTE i = 0; i < iMax; i++ )
 	{
 		if ( m_obj[i] != uid )
 			continue;
@@ -254,8 +254,8 @@ void CItemSpawn::AddObj(CGrayUID uid)
 		}
 	}
 
-	unsigned char iMax = maximum(GetAmount(), 1);
-	for ( unsigned char i = 0; i < iMax; i++ )
+	BYTE iMax = maximum(GetAmount(), 1);
+	for ( BYTE i = 0; i < iMax; i++ )
 	{
 		if ( !m_obj[i].IsValidUID() )
 		{
@@ -322,7 +322,7 @@ void CItemSpawn::KillChildren()
 	if (m_currentSpawned <= 0 )
 		return;
 
-	for ( unsigned char i = 0; i < m_currentSpawned; i++ )
+	for ( BYTE i = 0; i < m_currentSpawned; i++ )
 	{
 		CObjBase *pObj = m_obj[i].ObjFind();
 		if ( !pObj )
@@ -472,7 +472,7 @@ void  CItemSpawn::r_Write(CScript & s)
 	if ( iTotal <= 0 )
 		return;
 
-	for ( unsigned char i = 0; i < iTotal; i++ )
+	for ( BYTE i = 0; i < iTotal; i++ )
 	{
 		if ( !m_obj[i].IsValidUID() )
 			continue;


### PR DESCRIPTION
Fixed: In certain situations returning 0 inside a custom trigger caused TRIGGER keyword to return 2. Also, potentially every value between 0-8 could interfere with some internal check. Now any value < 100 can be safely returned and readed.