### PR TITLE
Fixed spawn COUNT prop and changed MoveNear accepted args type.

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -2914,10 +2914,9 @@ Changed: now double clicking a T_SPAWN_ITEM spawnitem has the same effect it has
 22-02-2016, Coruja
 Fixed: Enhanced clients not placing items on correct container GRID slot when using containers on 'list view' mode.
 
-
 23-02-2016, Coruja
 Fixed: Some clients not parsing correctly the last number/letter of client version.
-Changed: Function REPORTEDCLIVER.1 got removed, it's no longer needed because now REPORTEDCLIVER will return the full client version by default.
+Fixed: Spawn items resetting COUNT and AMOUNT values to 0 on server restart.
 
 25-02-2016, XuN
 Improved the code of NPC's SpellCasting engine: removed some code and updated a bit the current. Also moved some spells to give them higher priority (Healing > cure poison > buffs ...)
@@ -2934,3 +2933,6 @@ Fixed some spells not being correctly found in case of having multiple books sin
 
 Script Pack:
 	-sphere_defs.scp: Added SKF_DISABLED
+
+25-02-2015, Nolok
+Fixed: Spawn items sometimes created with random COUNT property.

--- a/src/graysvr/CItem.cpp
+++ b/src/graysvr/CItem.cpp
@@ -1414,7 +1414,7 @@ bool CItem::MoveToCheck( const CPointMap & pt, CChar * pCharMover )
 	return true;
 }
 
-bool CItem::MoveNearObj( const CObjBaseTemplate *pObj, int iSteps )
+bool CItem::MoveNearObj( const CObjBaseTemplate *pObj, WORD iSteps )
 {
 	ADDTOCALLSTACK("CItem::MoveNearObj");
 	// Put in the same container as another item.

--- a/src/graysvr/CItemSpawn.cpp
+++ b/src/graysvr/CItemSpawn.cpp
@@ -104,6 +104,7 @@ CItemSpawn::CItemSpawn(ITEMID_TYPE id, CItemBase *pDef) : CItem(ITEMID_WorldGem,
 {
 	ADDTOCALLSTACK("CItemSpawn::CItemSpawn");
 	UNREFERENCED_PARAMETER(id);	//forced in CItem(ITEMID_WorldGem , )
+	m_currentSpawned = 0;
 }
 
 CItemSpawn::~CItemSpawn()
@@ -200,7 +201,7 @@ void CItemSpawn::DelObj(CGrayUID uid)
 		return;
 
 	BYTE iMax = GetCount();
-	for ( unsigned char i = 0; i < iMax; i++ )
+	for ( BYTE i = 0; i < iMax; i++ )
 	{
 		if ( m_obj[i] != uid )
 			continue;
@@ -254,8 +255,8 @@ void CItemSpawn::AddObj(CGrayUID uid)
 		}
 	}
 
-	unsigned char iMax = maximum(GetAmount(), 1);
-	for ( unsigned char i = 0; i < iMax; i++ )
+	BYTE iMax = maximum(GetAmount(), 1);
+	for (BYTE i = 0; i < iMax; i++ )
 	{
 		if ( !m_obj[i].IsValidUID() )
 		{
@@ -322,7 +323,7 @@ void CItemSpawn::KillChildren()
 	if (m_currentSpawned <= 0 )
 		return;
 
-	for ( unsigned char i = 0; i < m_currentSpawned; i++ )
+	for (BYTE i = 0; i < m_currentSpawned; i++ )
 	{
 		CObjBase *pObj = m_obj[i].ObjFind();
 		if ( !pObj )
@@ -472,7 +473,7 @@ void  CItemSpawn::r_Write(CScript & s)
 	if ( iTotal <= 0 )
 		return;
 
-	for ( unsigned char i = 0; i < iTotal; i++ )
+	for (BYTE i = 0; i < iTotal; i++ )
 	{
 		if ( !m_obj[i].IsValidUID() )
 			continue;

--- a/src/graysvr/CObjBase.cpp
+++ b/src/graysvr/CObjBase.cpp
@@ -269,7 +269,7 @@ bool CObjBase::SetNamePool( LPCTSTR pszName )
 	return true;
 }
 
-bool CObjBase::MoveNearObj( const CObjBaseTemplate *pObj, int iSteps )
+bool CObjBase::MoveNearObj( const CObjBaseTemplate *pObj, WORD iSteps )
 {
 	ADDTOCALLSTACK("CObjBase::MoveNearObj");
 	ASSERT(pObj);
@@ -470,7 +470,7 @@ void CObjBase::SpeakUTF8Ex( const NWORD * pText, HUE_TYPE wHue, TALKMODE_TYPE mo
 	g_World.SpeakUNICODE( this, pText, wHue, mode, font, lang );
 }
 
-bool CObjBase::MoveNear( CPointMap pt, int iSteps )
+bool CObjBase::MoveNear( CPointMap pt, WORD iSteps )
 {
 	ADDTOCALLSTACK("CObjBase::MoveNear");
 	// Move to nearby this other object.
@@ -480,9 +480,8 @@ bool CObjBase::MoveNear( CPointMap pt, int iSteps )
 	for ( int i = 0; i < iSteps; i++ )
 	{
 		pt = ptOld;
-		pt.m_x += static_cast<short>(Calc_GetRandVal2(-iSteps, iSteps));
-		pt.m_y += static_cast<short>(Calc_GetRandVal2(-iSteps, iSteps));
-		if ( !pt.IsValidPoint() )	// hit the edge of the world, so go back to the previous valid position
+		pt.m_x += static_cast<WORD>(Calc_GetRandVal2(-iSteps, iSteps));
+		pt.m_y += static_cast<WORD>(Calc_GetRandVal2(-iSteps, iSteps));		if ( !pt.IsValidPoint() )	// hit the edge of the world, so go back to the previous valid position
 		{
 			pt = ptOld;
 			break;
@@ -2068,7 +2067,7 @@ bool CObjBase::r_Verb( CScript & s, CTextConsole * pSrc ) // Execute command fro
 				pObjNear = uid.ObjFind();
 				if ( !pObjNear )
 					return false;
-				MoveNearObj( pObjNear, static_cast<int>(piCmd[1]) );
+				MoveNearObj( pObjNear, static_cast<WORD>(piCmd[1]) );
 				if ( piCmd[2] )
 					Update();
 			}

--- a/src/graysvr/CObjBase.h
+++ b/src/graysvr/CObjBase.h
@@ -308,8 +308,8 @@ public:
 	// Location
 	virtual bool MoveTo(CPointMap pt, bool bForceFix = false) = 0;	// Move to a location at top level.
 
-	virtual bool MoveNear( CPointMap pt, int iSteps = 0 );
-	virtual bool MoveNearObj( const CObjBaseTemplate *pObj, int iSteps = 0 );
+	virtual bool MoveNear( CPointMap pt, WORD iSteps = 0 );
+	virtual bool MoveNearObj( const CObjBaseTemplate *pObj, WORD iSteps = 0 );
 
 	void inline SetNamePool_Fail( TCHAR * ppTitles );
 	bool SetNamePool( LPCTSTR pszName );
@@ -1098,7 +1098,7 @@ public:
 		return MoveToUpdate( pt, bForceFix);
 	}
 	bool MoveToCheck( const CPointMap & pt, CChar * pCharMover = NULL );
-	virtual bool MoveNearObj( const CObjBaseTemplate *pItem, int iSteps = 0 );
+	virtual bool MoveNearObj( const CObjBaseTemplate *pItem, WORD iSteps = 0 );
 
 	CItem* GetNext() const
 	{
@@ -3216,11 +3216,11 @@ public:
 		FixClimbHeight();
 	}
 	bool MoveToValidSpot(DIR_TYPE dir, int iDist, int iDistStart = 1, bool bFromShip = false);
-	virtual bool MoveNearObj( const CObjBaseTemplate *pObj, int iSteps = 0 )
+	virtual bool MoveNearObj( const CObjBaseTemplate *pObj, WORD iSteps = 0 )
 	{
 		return CObjBase::MoveNearObj(pObj, iSteps);
 	}
-	bool MoveNear( CPointMap pt, int iSteps = 0 )
+	bool MoveNear( CPointMap pt, WORD iSteps = 0 )
 	{
 		return CObjBase::MoveNear(pt, iSteps);
 	}

--- a/src/graysvr/CSector.cpp
+++ b/src/graysvr/CSector.cpp
@@ -905,8 +905,8 @@ void CSector::RespawnDeadNPCs()
 		pChar->NPC_LoadScript(true);
 
 		// Res them back to their "home".
-		int iDist = pChar->m_pNPC->m_Home_Dist_Wander;
-		pChar->MoveNear( pChar->m_ptHome, ( iDist < SHRT_MAX ) ? iDist : 4 );
+		WORD iDist = pChar->m_pNPC->m_Home_Dist_Wander;
+		pChar->MoveNear( pChar->m_ptHome, iDist );
 		pChar->NPC_CreateTrigger(); //Removed from NPC_LoadScript() and triggered after char placement
 		pChar->Spell_Resurrection();
 	}


### PR DESCRIPTION
Fixed: Spawn items created with random COUNT property.
Changed: MoveNear functions now accept WORD iStep argument instead of int, since x and y coordinates are stored as WORD.