### PR TITLE
Fixed Import/Export behaviors to be more useful with less work after (Reopened)

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -234,3 +234,15 @@ Changed: Updated internal SQLite libs v3.14.1 to v3.14.2.
 05-10-2016, Coruja
 Fixed: Guards NPCs already placed on world not attacking criminal/murderer chars walking nearby.
 Fixed: Potions creating cooldown memory (layer_flag_potionused) using wrong name.
+
+06-10-2016, Ares
+Changed: New Options for export to exclude own character (SRC) when performing export. The options are now:
+	- 1: Only items
+	- 2: Only characters without own character.
+	- 3: Items and characters without own character. [1+2]
+	- (4: Include own Character. But this is meaningless without flag 2)
+	- (5: Only items including own character makes no sense. ;-) )
+	- 6: Only characters including own character. [2+4]
+	- 7: Items and characters including own character. [1+2+4]
+Fixed: A rarely occuring bug when importing characters: Sometimes when characters are imported, there is a chance for identical items at same place (in backpack), which are deleted. This shouldn't happen anymore.
+Fixed: Importing items with same BASEID and different DISPID at the same place in world removes one of the items unexpectedly. This is especially the case for WSC imports, where same DISPIDs of the same BASEID are is almost always intended. (For example when a part of the static is in game for a while, or migrated between CentrED and a Building-Sphere-Server) The fix is: Such items are not deleted anymore, only when the dispid (and other stuff) matches as well.

--- a/src/graysvr/CItem.cpp
+++ b/src/graysvr/CItem.cpp
@@ -991,6 +991,27 @@ bool CItem::IsSameType( const CObjBase * pObj ) const
 	return( true );
 }
 
+// Checks whether the items are fully identical.
+bool CItem::IsIdentical( const CObjBase * pObj )
+{
+	ADDTOCALLSTACK("CItem::IsIdentical");
+	const CItem * pItem = dynamic_cast <const CItem*> ( pObj );
+
+	if ( !IsSameType(pItem) )
+		return ( false );
+
+	// Do not compare with dupelist here, the item should be really identical.
+	if ( ! CItemBase::IsValidDispID( pItem->GetDispID() ))
+		return( false );
+	if ( pItem->GetDispID() != GetDispID())
+		return( false );
+
+	if (!m_TagDefs.Compare( &( pItem->m_TagDefs ) ))
+		return false ;
+
+	return( true );
+}
+
 bool CItem::IsStackableException() const
 {
 	ADDTOCALLSTACK("CItem::IsStackableException");

--- a/src/graysvr/CObjBase.h
+++ b/src/graysvr/CObjBase.h
@@ -1032,6 +1032,7 @@ public:
 		return (m_Can & wCan) ? true : false;
 	}
 	virtual bool  IsSameType( const CObjBase * pObj ) const;
+	virtual bool  IsIdentical( const CObjBase * pObj );
 	bool  Stack( CItem * pItem );
 	DWORD ConsumeAmount( DWORD iQty = 1, bool fTest = false );
 

--- a/src/graysvr/CWorld.h
+++ b/src/graysvr/CWorld.h
@@ -204,7 +204,7 @@ enum IMPFLAGS_TYPE	// IMPORT and EXPORT flags.
 	IMPFLAGS_ITEMS = 0x01,		// 0x01 = items,
 	IMPFLAGS_CHARS = 0x02,		// 0x02 = characters
 	IMPFLAGS_BOTH  = 0x03,		// 0x03 = both
-	IMPFLAGS_PLAYERS = 0x04,
+	IMPFLAGS_SELF = 0x04,		// 0x04 = including self
 	IMPFLAGS_RELATIVE = 0x10,	// 0x10 = distance relative. dx, dy to you
 	IMPFLAGS_ACCOUNT = 0x20		// 0x20 = recover just this account/char	(and all it is carrying)
 };


### PR DESCRIPTION
As we have experienced at Alathair, exporting chars is nearly always meant to export other chars but not the own char, a flag here would be neccessary to control that. The default case should be not to export SRC itself. but it could be optionally turned on using the bitflag 0100. So if you want to export chars including yourself use flag 6. If it should include items use flag 7. Otherwise 1 2 and 3 will not include SRC.

Effectively this means:
01 (01) Only items
02 (02) Only chars without own character.
01+02 (03) Items and chars without own character.
02+04 (06) Only chars including own character.
01+02+04 (07) Items and chars including own character.

Additionaly Importing SCP and WSC Files needs a differentiated behavior for the different file types: Since SCP files are used to backup characters and items with several tags, props and stuff, they chars need to be migrated. On the other hand WSC files are used to import flat items (or chars - but there is nothing to be handled for flat chars), so these imported items should simply be merged.

This fixes the following bugs:

* Sometimes when Characters are imported, then there is a chance for identical items at same place (in backpack), which are deleted. This shouldn't happen anymore.
* Importing items with same BASEID and different DISPID at the same place in world removes one of the items unexpectedly. This is especially the case for WSC imports, where same DISPIDs of the same BASEID are is almost always intended. (For example when a part of the static is in game for a while, or migrated between CentrED and a Building-Sphere-Server) Fix: Such items are not deleted anymore, only when the dispid matches as well.