### PR TITLE
Fix for a critical bug within the background save mechanism

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -246,3 +246,6 @@ Changed: New Options for export to exclude own character (SRC) when performing e
 	- 7: Items and characters including own character. [1+2+4]
 Fixed: A rarely occuring bug when importing characters: Sometimes when characters are imported, there is a chance for identical items at same place (in backpack), which are deleted. This shouldn't happen anymore.
 Fixed: Importing items with same BASEID and different DISPID at the same place in world removes one of the items unexpectedly. This is especially the case for WSC imports, where same DISPIDs of the same BASEID are is almost always intended. (For example when a part of the static is in game for a while, or migrated between CentrED and a Building-Sphere-Server) The fix is: Such items are not deleted anymore, only when the dispid (and other stuff) matches as well.
+
+08-10-2016, Ares
+Fixed: Critical Bug in background save mechanism where an unsaved offline player character disappears from worldsave when moved to an already saved sector.

--- a/src/graysvr/CCharact.cpp
+++ b/src/graysvr/CCharact.cpp
@@ -3511,7 +3511,7 @@ bool CChar::MoveToChar(CPointMap pt, bool bForceFix)
 
 		// We cannot put this char in non-disconnect state.
 		SetDisconnected();
-		pSector->m_Chars_Disconnect.InsertHead(this);
+		pSector->MoveDisconnectedCharToSector(this);
 		SetUnkPoint(pt);
 		return true;
 	}

--- a/src/graysvr/CSector.cpp
+++ b/src/graysvr/CSector.cpp
@@ -798,16 +798,15 @@ void CSector::MoveItemToSector( CItem * pItem, bool fActive )
 	}
 }
 
-bool CSector::MoveCharToSector( CChar * pChar )
+
+void CSector::CheckSaveParity(CChar* pChar)
 {
-	ADDTOCALLSTACK("CSector::MoveCharToSector");
-	// Move a CChar into this CSector.
-	// ASSUME: called from CChar.MoveToChar() assume ACtive char.
+	ADDTOCALLSTACK("CSector::CheckSaveParity");
+	// NOTE:
+	// pChar is not yet added to any charlist of this sector
+	// ASSUME: called from CSector.MoveCharToSector() or CSector.MoveDisconnectedCharToSector().
 
-	if ( IsCharActiveIn(pChar) )
-		return false;	// already here
-
-	// Check my save parity vs. this sector's
+	// Check my save parity vs. this sector's and save out if not saved yet
 	if ( pChar->IsStatFlag( STATF_SaveParity ) != m_fSaveParity )
 	{
 		if ( g_World.IsSaving())
@@ -827,8 +826,39 @@ bool CSector::MoveCharToSector( CChar * pChar )
 			}
 		}
 	}
+}
+
+bool CSector::MoveCharToSector(CChar * pChar)
+{
+	ADDTOCALLSTACK("CSector::MoveCharToSector");
+	// Move a CChar into this CSector.
+	// NOTE:
+	//   m_pt is still the old location. Not moved yet!
+	// ASSUME: called from CChar.MoveToChar() assume Active char.
+
+	if (IsCharActiveIn(pChar))
+		return false;	// already here
+
+	CheckSaveParity(pChar);
 
 	m_Chars_Active.AddCharToSector(pChar);	// remove from previous spot.
+	return(true);
+}
+
+bool CSector::MoveDisconnectedCharToSector(CChar * pChar)
+{
+	ADDTOCALLSTACK("CSector::MoveDisconnectedCharToSector");
+	// Move a CChar into this CSector.
+	// NOTE:
+	//   m_pt is still the old location. Not moved yet!
+	// ASSUME: called from CChar.MoveToChar() assume disconnected char.
+
+	if (IsCharDisconnectedIn(pChar))
+		return false;	// already here
+
+	CheckSaveParity(pChar);
+
+	m_Chars_Disconnect.InsertHead(pChar);	// remove from previous spot.
 	return true;
 }
 

--- a/src/graysvr/CWorld.h
+++ b/src/graysvr/CWorld.h
@@ -177,7 +177,11 @@ public:
 		m_Chars_Active.ClientDetach();
 	}
 	bool MoveCharToSector( CChar * pChar );
+	bool MoveDisconnectedCharToSector(CChar * pChar);
+private:
+	void CheckSaveParity(CChar* pChar);
 
+public:
 	// General.
 	virtual bool r_LoadVal( CScript & s );
 	virtual bool r_WriteVal( LPCTSTR pszKey, CGString & sVal, CTextConsole * pSrc );


### PR DESCRIPTION
We at alathair have experienced a strange bug when moving offline player characters. They disappeared from Worldsave after moving them. With the third following worldsave the character appeared again.

Reproduce:
1. Place a player character at 6000,4000 and logout.
2. Make a full world save.
3. Type 'save' into console to start the next background save.
4. Move this logged out player to 10,10. (DO NOT LOGIN WITH THIS CHARACTER!)
5. Finish the background save.
Result: The character disappeared from Worldsave.
Reason: Offline Characters save pairity is not checked.

Furthermore it doesnt appear in the second save, because its pairity is still the previous one - so it appears to be already saved. Finally with the third save its pairity is unequal so it gets saved and appears in the worldsave again.

Fix:
When moving offline characters the character is added correctly to the sector it is moved to, but its save pairity is also checked, and when it is not saved, it gets saved.
