### PR TITLE
Added some general function calls for client login/logout at characters.

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -254,3 +254,6 @@ Fixed: Critical Bug in background save mechanism where an unsaved offline player
 Fixed: NPCs losing 'statf_spawned' flag after server restart.
 Fixed: Nightsight buff icon not being enabled/disabled when using NIGHTSIGHT function or changing 'statf_nightsight' char flag.
 Changed: Updated internal SQLite libs v3.14.2 to v3.15.0.
+
+22-10-2016, Ares
+Added: f_onchar_login/f_onchar_logout functions (usually placed in sphere_serv_triggers.scp) are now called for clients login/-out at characters. This is independent from character definition or events to be more reliable. SRC is the character.

--- a/src/graysvr/CClient.cpp
+++ b/src/graysvr/CClient.cpp
@@ -128,6 +128,9 @@ void CClient::CharDisconnect()
 		return;
 
 	Announce(false);
+	CScriptTriggerArgs LogoutArgs;
+	m_pChar->r_Call("f_onchar_logout", m_pChar, &LogoutArgs);
+
 	bool bCanInstaLogOut = CanInstantLogOut();
 	int	iLingerTime = g_Cfg.m_iClientLingerTime;
 

--- a/src/graysvr/CClientMsg.cpp
+++ b/src/graysvr/CClientMsg.cpp
@@ -3688,6 +3688,8 @@ BYTE CClient::Setup_Start(CChar *pChar) // Send character startup stuff to playe
 
 	m_pAccount->m_TagDefs.DeleteKey("LastLogged");
 	Announce(true);		// announce you to the world
+	CScriptTriggerArgs LoginArgs;
+	m_pChar->r_Call("f_onchar_login", m_pChar, &LoginArgs);
 
 	// Don't login on the water, bring us to nearest shore (unless I can swim)
 	if ( !IsPriv(PRIV_GM) && !m_pChar->Char_GetDef()->Can(CAN_C_SWIM) && m_pChar->IsSwimming() )


### PR DESCRIPTION
f_onchar_login/f_onchar_logout functions (usually placed in sphere_serv_triggers.scp) are now called for clients login/-out at characters. SRC is the character. This is independent from character definition or events to be more reliable.

The reason for this function calls is that there are sometimes cases where a functionality is really scoped to a client. Okay you could use events. But especially our tech staff sometimes makes experiments, and in these cases there are sometimes no events and stuff like that. But a reliable trigger is requred. So here it is.

