### PR TITLE
 Normally with EquippedCast disabled, items in layer 1 or 2 will be u…

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -933,3 +933,6 @@ Possible fix for stat cap issue when the sum of the char stats reach StatCap - 1
 Fixed: Deeds not setting ATTR=attr_move_never on multi parent item after create it.
 Fixed: Deeds showing multi targets on wrong Y position.
 Fixed: 'memory_guard' memories not being removed after its linked item get deleted.
+
+29-12-2017, Drk84
+- Fix for the spellchanneling item property.

--- a/src/graysvr/CCharSpell.cpp
+++ b/src/graysvr/CCharSpell.cpp
@@ -2532,7 +2532,7 @@ bool CChar::Spell_Unequip(LAYER_TYPE layer)
 		}
 		else if ( !CanMove(pItem) )
 			return false;
-		else if ( !pItem->IsTypeSpellbook() && !pItem->IsType(IT_WAND) && !pItem->GetDefKey("SpellChanneling", true) )
+		else if ( !pItem->IsTypeSpellbook() && !pItem->IsType(IT_WAND) && !pItem->GetDefNum("SpellChanneling", true) )
 			ItemBounce(pItem);
 	}
 	return true;


### PR DESCRIPTION
…nequipped when casting a spell, if you set one these items with the SpellChanneling property the items will be correctly not unequipped.

The problem  arise when you "remove" (by setting it  to 0)  the SpellChanneling property in an item that had it, the check in Spell_Unequip used GetDefKey instead of GetDefNum.

  So even if the SpellChanneling was set to 0 the check was still considered valid.