### PR TITLE
Fire and smelt like 55i + SkillGain

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -1578,4 +1578,7 @@ Fixed: Trigger @Destroy not being called on spawned chars/items when negate the 
 04-09-2019, Coruja
 Fixed: Linux builds throwing buffer overflow exception when initializing.
 Fixed: Smelting ores on forge always failing the action.
-[sphere.ini] : Added SmeltOreOnDclick to work like in 55i with fire effect. Nirad
+[sphere.ini] : Added SmeltOreOnDclick to work like in 55i with fire effect.Nirad
+
+05-09-2019, Coruja
+Fixed: Linux builds not parsing text characters correctly.

--- a/makefile
+++ b/makefile
@@ -147,8 +147,8 @@ build:	git flags gray
 	@$(CC) $(O_FLAGS) $(C_FLAGS) -o $(EXE) ./src/common/*.o ./src/common/libev/*.o ./src/common/sqlite/*.o ./src/common/twofish/*.o ./src/common/zlib/*.o ./src/graysvr/*.o ./src/network/*.o ./src/sphere/*.o $(INCLUDE_LIBS)
 
 clean:
-	rm -rf ./src/*.o
-
+	rm -rf ./$(EXE)
+	find . -name \*.o -type f -delete
 
 git:
 ifdef GITREVISION

--- a/src/common/grayproto.h
+++ b/src/common/grayproto.h
@@ -365,7 +365,7 @@ enum PACKETENC_TYPE		// encoded packets used by PACKET_EncodedData
 
 enum PARTYMSG_TYPE
 {
-	PARTYMSG_Add = 1,			// client <-> server
+	PARTYMSG_Add = 0x1,			// client <-> server
 	PARTYMSG_Remove,			// client <-> server
 	PARTYMSG_MsgMember,			// client  -> server
 	PARTYMSG_MsgAll,			// client <-> server
@@ -520,13 +520,13 @@ enum INPVAL_TYPE
 
 enum MAPCMD_TYPE
 {
-	MAPCMD_AddPin				= 1,
-	MAPCMD_InsertPin			= 2,
-	MAPCMD_MovePin				= 3,
-	MAPCMD_RemovePin			= 4,
-	MAPCMD_ClearPins			= 5,
-	MAPCMD_ToggleEdit_Request	= 6,
-	MAPCMD_ToggleEdit_Reply		= 7
+	MAPCMD_AddPin = 0x1,
+	MAPCMD_InsertPin,
+	MAPCMD_MovePin,
+	MAPCMD_RemovePin,
+	MAPCMD_ClearPins,
+	MAPCMD_ToggleEdit_Request,
+	MAPCMD_ToggleEdit_Reply
 };
 
 enum MAPWAYPOINT_TYPE
@@ -710,7 +710,7 @@ enum GAMECLIENT_TYPE
 	CLIENTTYPE_2D,	// 2D classic client
 	CLIENTTYPE_3D,	// 3D classic client
 	CLIENTTYPE_KR,	// KR enhanced client
-	CLIENTTYPE_EC	// SA enhanced client
+	CLIENTTYPE_EC	// SA+ enhanced client
 };
 
 enum RACE_TYPE

--- a/src/common/os_unix.h
+++ b/src/common/os_unix.h
@@ -25,7 +25,7 @@ typedef long				LONG;				// 32 bits
 typedef long long			LONGLONG, INT64;	// 64 bits
 typedef unsigned long long	ULONGLONG, UINT64;	// 64 bits
 
-typedef wchar_t				WCHAR;
+typedef unsigned short		WCHAR;
 typedef char				TCHAR;
 typedef char				*LPSTR, *LPTSTR;
 typedef const char			*LPCSTR, *LPCTSTR;

--- a/src/graysvr/CCharSkill.cpp
+++ b/src/graysvr/CCharSkill.cpp
@@ -1451,7 +1451,7 @@ bool CChar::Skill_SmeltOre(CItem *pOre)
 
 	UpdateDir(m_Act_p);
 
-	if ( !Skill_CheckSuccess(SKILL_MINING, pIngotDef->m_ttIngot.m_iSkillReq / 10) )
+	if ( !Skill_UseQuick(SKILL_MINING, pIngotDef->m_ttIngot.m_iSkillReq / 10) )
 	{
 		pOre->ConsumeAmount(maximum(1, (pOre->GetAmount() / 2)));
 		SysMessageDefault(DEFMSG_SMELT_FAIL);

--- a/src/graysvr/CClientUse.cpp
+++ b/src/graysvr/CClientUse.cpp
@@ -364,6 +364,10 @@ bool CClient::Cmd_Use_Item(CItem *pItem, bool fTestTouch, bool fScript)
 		}
 
 		case IT_ORE:
+			if (g_Cfg.m_iSmeltOreOnDclick)
+			{
+				return m_pChar->Skill_SmeltOre(pItem);
+			}
 			addTarget(CLIMODE_TARG_USE_ITEM, g_Cfg.GetDefaultMsg(DEFMSG_ITEMUSE_ORE));
 			return true;
 

--- a/src/graysvr/CResource.cpp
+++ b/src/graysvr/CResource.cpp
@@ -142,6 +142,7 @@ CResource::CResource()
 	m_iAttackerTimeout = 300 * TICK_PER_SEC;
 	m_iNotoTimeout = 30 * TICK_PER_SEC;
 	m_iMaxSkill = SKILL_QTY;
+	m_iSmeltOreOnDclick = false;
 
 	m_iDistanceWhisper = 1;
 	m_iDistanceYell = UO_MAP_VIEW_RADAR;
@@ -534,6 +535,7 @@ enum RC_TYPE
 	RC_SECTORSLEEP,					// m_iSectorSleepMask
 	RC_SECURE,						// m_fSecure
 	RC_SKILLPRACTICEMAX,			// m_iSkillPracticeMax
+	RC_SMELTOREONDCLICK,			// m_iSmeltOreOnDclick
 	RC_SNOOPCRIMINAL,				// m_iSnoopCriminal
 	RC_SPEECHOTHER,					// m_sSpeechOther
 	RC_SPEECHPET,					// m_sSpeechPet
@@ -759,6 +761,7 @@ const CAssocReg CResource::sm_szLoadKeys[RC_QTY + 1] =
 	{"SECTORSLEEP",					{ELEM_INT,		OFFSETOF(CResource, m_iSectorSleepMask),				0}},
 	{"SECURE",						{ELEM_BOOL,		OFFSETOF(CResource, m_fSecure),							0}},
 	{"SKILLPRACTICEMAX",			{ELEM_WORD,		OFFSETOF(CResource, m_iSkillPracticeMax),				0}},
+	{"SMELTOREONDCLICK",			{ELEM_BOOL,		OFFSETOF(CResource, m_iSmeltOreOnDclick),				0} },
 	{"SNOOPCRIMINAL",				{ELEM_INT,		OFFSETOF(CResource, m_iSnoopCriminal),					0}},
 	{"SPEECHOTHER",					{ELEM_CSTRING,	OFFSETOF(CResource, m_sSpeechOther),					0}},
 	{"SPEECHPET",					{ELEM_CSTRING,	OFFSETOF(CResource, m_sSpeechPet),						0}},
@@ -1087,6 +1090,9 @@ bool CResource::r_LoadVal(CScript &s)
 			break;
 		case RC_PACKETDEATHANIMATION:
 			m_iPacketDeathAnimation = (s.GetArgVal() > 0);
+			break;
+		case RC_SMELTOREONDCLICK:
+			m_iSmeltOreOnDclick = s.GetArgVal() ? true : false;
 			break;
 		case RC_SKILLPRACTICEMAX:
 			m_iSkillPracticeMax = static_cast<WORD>(s.GetArgLLVal());

--- a/src/graysvr/CResource.h
+++ b/src/graysvr/CResource.h
@@ -792,6 +792,7 @@ public:
 	int m_iCombatSpeedEra;					// define swing speed formula to use on physical combat
 	WORD m_iSkillPracticeMax;				// max skill level a player can practice on dummies/targets upto
 	bool m_iPacketDeathAnimation;			// packet 02c
+	bool m_iSmeltOreOnDclick;				// smelt ore on dclick like 55i
 
 	// Flags for controlling pvp/pvm behaviour of players
 	int m_iCombatFlags;						// combat flags

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -520,6 +520,10 @@ OverSkillMultiply=2
 // NPC_AI_THREAT			0800	Make NPCs select combat target based on highest threat level (damage done) instead closest distance
 //NPCAI=0
 
+// Ore will be smelth on double click if near a forge  like in 55i
+// Setting this to 0 disables thih feature.
+SmeltOreOnDclick=0
+
 ///////////////////////////////////////////////////////////////
 //////// Crime/Murder/Karma/Fame/Guard Settings
 ///////////////////////////////////////////////////////////////


### PR DESCRIPTION
SmeltOreOnDclik to smelt ore on dclick near a forge this cancel the curent target option
Default: false
Added in the ini :
// Ore will be smelth on double click if near a forge like in 55i
// Setting this to 0 disables thih feature.
SmeltOreOnDclick=0

Sorry I had to reopen a pr I have make a bad move on the other branch.