### PR TITLE
Add FreeBSD and Clang support

### DIFF
--- a/makefile.fbsd
+++ b/makefile.fbsd
@@ -20,10 +20,10 @@ ifdef DEBUG
 endif
 BUILD_DEFS		+= -D_THREAD_TRACK_CALLSTACK
 
-#ifneq ($(shell git rev-parse --git-dir),)
-#	GITREVISION	= $(shell expr $(shell git rev-list --count HEAD) - 2406)
-#	GITHASH		= $(shell git rev-parse --short HEAD)
-#endif
+ifneq ($(shell git rev-parse --git-dir),)
+	GITREVISION	= $(shell expr $(shell git rev-list --count HEAD) - 2406)
+	GITHASH		= $(shell git rev-parse --short HEAD)
+endif
 
 O_FLAGS		= $(CODE_GEN_FLAGS) $(GENERAL_FLAGS) $(O_WARNING_FLAGS)
 CO_FLAGS	= $(CODE_GEN_FLAGS) $(GENERAL_FLAGS) $(CO_WARNING_FLAGS)

--- a/makefile.fbsd
+++ b/makefile.fbsd
@@ -1,0 +1,172 @@
+# Use: gmake -f makefile.fbsd
+CODE_GEN_FLAGS		= -fexceptions -fnon-call-exceptions
+GENERAL_FLAGS		= -pipe
+LINKER_FLAGS		= -s -L/usr/local/lib/mysql -lmysqlclient -lpthread -ldl -lm -lstdc++
+OPTIMIZATION_FLAGS	= -O2 -ffast-math -fno-strict-aliasing -fno-omit-frame-pointer
+O_WARNING_FLAGS		= -Wall -Wno-switch -Wno-unused-result
+CO_WARNING_FLAGS	= -Wall -Wno-implicit-function-declaration -Wno-unused-result
+ifdef x86
+	ARCH_FLAGS	= -m32 -Dx86
+else
+	ARCH_FLAGS	= -m64 -Dx64
+endif
+
+ifdef NIGHTLY
+	BUILD_DEFS	= -D_NIGHTLYBUILD
+endif
+ifdef DEBUG
+	BUILD_DEFS	= -D_DEBUG
+	GENERAL_FLAGS	+= -ggdb3
+endif
+BUILD_DEFS		+= -D_THREAD_TRACK_CALLSTACK
+
+#ifneq ($(shell git rev-parse --git-dir),)
+#	GITREVISION	= $(shell expr $(shell git rev-list --count HEAD) - 2406)
+#	GITHASH		= $(shell git rev-parse --short HEAD)
+#endif
+
+O_FLAGS		= $(CODE_GEN_FLAGS) $(GENERAL_FLAGS) $(O_WARNING_FLAGS)
+CO_FLAGS	= $(CODE_GEN_FLAGS) $(GENERAL_FLAGS) $(CO_WARNING_FLAGS)
+C_FLAGS		= $(ARCH_FLAGS) $(BUILD_DEFS) $(OPTIMIZATION_FLAGS)
+CC_FLAGS	= $(ARCH_FLAGS) $(BUILD_DEFS) $(OPTIMIZATION_FLAGS)
+
+CC	= clang -std=c++11
+CCO	= clang
+EXE	= spheresvr
+
+SRC :=	./src/graysvr/CAccount.cpp \
+	./src/graysvr/CBase.cpp \
+	./src/graysvr/CChar.cpp \
+	./src/graysvr/CCharAct.cpp \
+	./src/graysvr/CCharBase.cpp \
+	./src/graysvr/CCharFight.cpp \
+	./src/graysvr/CCharNPC.cpp \
+	./src/graysvr/CCharNPCAct.cpp \
+	./src/graysvr/CCharNPCPet.cpp \
+	./src/graysvr/CCharNPCStatus.cpp \
+	./src/graysvr/CCharSkill.cpp \
+	./src/graysvr/CCharSpell.cpp \
+	./src/graysvr/CCharStatus.cpp \
+	./src/graysvr/CCharUse.cpp \
+	./src/graysvr/CChat.cpp \
+	./src/graysvr/CClient.cpp \
+	./src/graysvr/CClientDialog.cpp \
+	./src/graysvr/CClientEvent.cpp \
+	./src/graysvr/CClientLog.cpp \
+	./src/graysvr/CClientMsg.cpp \
+	./src/graysvr/CClientTarg.cpp \
+	./src/graysvr/CClientUse.cpp \
+	./src/graysvr/CContain.cpp \
+	./src/graysvr/CGMPage.cpp \
+	./src/graysvr/CItem.cpp \
+	./src/graysvr/CItemBase.cpp \
+	./src/graysvr/CItemMulti.cpp \
+	./src/graysvr/CItemMultiCustom.cpp \
+	./src/graysvr/CItemShip.cpp \
+	./src/graysvr/CItemSpawn.cpp \
+	./src/graysvr/CItemStone.cpp \
+	./src/graysvr/CItemVend.cpp \
+	./src/graysvr/CLog.cpp \
+	./src/graysvr/CObjBase.cpp \
+	./src/graysvr/CParty.cpp \
+	./src/graysvr/CPathFinder.cpp \
+	./src/graysvr/CPingServer.cpp \
+	./src/graysvr/CResource.cpp \
+	./src/graysvr/CResourceCalc.cpp \
+	./src/graysvr/CResourceDef.cpp \
+	./src/graysvr/CSector.cpp \
+	./src/graysvr/CServer.cpp \
+	./src/graysvr/CServRef.cpp \
+	./src/graysvr/CUnixTerminal.cpp \
+	./src/graysvr/CWebPage.cpp \
+	./src/graysvr/CWorld.cpp \
+	./src/graysvr/CWorldImport.cpp \
+	./src/graysvr/CWorldMap.cpp \
+	./src/graysvr/graysvr.cpp \
+	./src/common/twofish/twofish2.cpp \
+	./src/common/libev/wrapper_ev.c \
+	./src/common/zlib/adler32.c \
+	./src/common/zlib/compress.c \
+	./src/common/zlib/crc32.c \
+	./src/common/zlib/deflate.c \
+	./src/common/zlib/gzclose.c \
+	./src/common/zlib/gzlib.c \
+	./src/common/zlib/gzread.c \
+	./src/common/zlib/gzwrite.c \
+	./src/common/zlib/infback.c \
+	./src/common/zlib/inffast.c \
+	./src/common/zlib/inflate.c \
+	./src/common/zlib/inftrees.c \
+	./src/common/zlib/trees.c \
+	./src/common/zlib/uncompr.c \
+	./src/common/zlib/zutil.c \
+	./src/common/CArray.cpp \
+	./src/common/CAssoc.cpp \
+	./src/common/CCacheableScriptFile.cpp \
+	./src/common/CCSVFile.cpp \
+	./src/common/CDataBase.cpp \
+	./src/common/CEncrypt.cpp \
+	./src/common/CExpression.cpp \
+	./src/common/CException.cpp \
+	./src/common/CFile.cpp \
+	./src/common/CFileList.cpp \
+	./src/common/CGrayData.cpp \
+	./src/common/CGrayInst.cpp \
+	./src/common/CGrayMap.cpp \
+	./src/common/CListDefMap.cpp \
+	./src/common/CMD5.cpp \
+	./src/common/CQueue.cpp \
+	./src/common/CRect.cpp \
+	./src/common/CRegion.cpp \
+	./src/common/CResourceBase.cpp \
+	./src/common/CScript.cpp \
+	./src/common/CScriptObj.cpp \
+	./src/common/CSectorTemplate.cpp \
+	./src/common/CSocket.cpp \
+	./src/common/CTime.cpp \
+	./src/common/CString.cpp \
+	./src/common/CVarDefMap.cpp \
+	./src/common/CVarFloat.cpp \
+	./src/common/graycom.cpp \
+	./src/common/sqlite/SQLite.cpp \
+	./src/common/sqlite/sqlite3.c \
+	./src/sphere/mutex.cpp \
+	./src/sphere/strings.cpp \
+	./src/sphere/threads.cpp \
+	./src/sphere/linuxev.cpp \
+	./src/sphere/asyncdb.cpp \
+	./src/sphere/ProfileData.cpp \
+	./src/network/network.cpp \
+	./src/network/packet.cpp \
+	./src/network/send.cpp \
+	./src/network/receive.cpp
+
+
+.PHONY:	build clean
+
+build:	git flags gray
+	@$(CC) $(O_FLAGS) $(C_FLAGS) -o $(EXE) ./src/common/*.o ./src/common/libev/*.o ./src/common/sqlite/*.o ./src/common/twofish/*.o ./src/common/zlib/*.o ./src/graysvr/*.o ./src/network/*.o ./src/sphere/*.o $(LINKER_FLAGS)
+
+clean:
+	rm -rf ./$(EXE)
+	find . -name \*.o -type f -delete
+
+git:
+ifdef GITREVISION
+	@echo 'Current build revision: $(GITREVISION) (Git hash: $(GITHASH))'
+	@echo '#define __GITREVISION__ $(GITREVISION)' > ./src/common/version/GitRevision.h
+	@echo '#define __GITHASH__ "$(GITHASH)"' >> ./src/common/version/GitRevision.h
+endif
+
+flags:
+	@echo 'Compiler flags: $(CC) $(O_FLAGS) $(C_FLAGS)'
+
+gray:	$(SRC:.cpp=.o) $(SRC:.c=.co)
+
+%.o:	%.cpp
+	@echo '  Compiling $<'
+	@$(CC) -c $(O_FLAGS) $(C_FLAGS) $< -o $@
+
+%.co:	%.c
+	@echo '  Compiling $<'
+	@$(CCO) -c $(CO_FLAGS) $(CC_FLAGS) $< -o $(@:.co=.o)

--- a/src/common/CArray.h
+++ b/src/common/CArray.h
@@ -11,6 +11,9 @@
 #ifdef __linux
 	#define STANDARD_CPLUSPLUS_THIS(_x_) this->_x_
 #endif
+#ifdef __FreeBSD__
+	#define STANDARD_CPLUSPLUS_THIS(_x_) this->_x_
+#endif
 
 ///////////////////////////////////////////////////////////
 // CGObListRec

--- a/src/common/CAssoc.h
+++ b/src/common/CAssoc.h
@@ -43,7 +43,7 @@ enum ELEM_TYPE	// define types of structure/record elements.
 };
 
 #ifndef OFFSETOF			// stddef.h ?
-	#define OFFSETOF(s,m)   	(uint)( (BYTE *)&(((s *)0)->m) - (BYTE *)0 )
+	#define OFFSETOF(s,m)   	(unsigned int)( (BYTE *)&(((s *)0)->m) - (BYTE *)0 )
 #endif
 
 struct CElementDef

--- a/src/common/CAssoc.h
+++ b/src/common/CAssoc.h
@@ -43,7 +43,7 @@ enum ELEM_TYPE	// define types of structure/record elements.
 };
 
 #ifndef OFFSETOF			// stddef.h ?
-	#define OFFSETOF(s,m)   	(int)( (BYTE *)&(((s *)0)->m) - (BYTE *)0 )
+	#define OFFSETOF(s,m)   	(uint)( (BYTE *)&(((s *)0)->m) - (BYTE *)0 )
 #endif
 
 struct CElementDef

--- a/src/common/CSocket.cpp
+++ b/src/common/CSocket.cpp
@@ -1,4 +1,7 @@
 #include "../graysvr/graysvr.h"
+#ifdef __FreeBSD__
+	#include <errno.h>
+#endif
 
 ///////////////////////////////////////////////////////////
 // CSocketAddressIP

--- a/src/common/CTime.cpp
+++ b/src/common/CTime.cpp
@@ -7,7 +7,11 @@
 ULONGLONG GetTickCount64()
 {
 	struct timespec ts;
+#ifdef __FreeBSD__
+	clock_gettime(CLOCK_MONOTONIC_FAST, &ts);
+#else
 	clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
 	return (static_cast<ULONGLONG>(ts.tv_sec * 10000) + (ts.tv_nsec / 100000)) / 10;
 }
 #endif

--- a/src/common/grayver.h
+++ b/src/common/grayver.h
@@ -38,10 +38,20 @@
 	#define SPHERE_VER_FILEOS		VOS_UNKNOWN
 #endif
 
-#if defined(_WIN64) || defined(x64)
-	#define SPHERE_VER_ARCH			"64bit"
+#if defined(_WIN32)
+	#define SPHERE_PLATFORM			"Windows"
+#elif defined(__linux__)
+	#define SPHERE_PLATFORM			"Linux"
+#elif defined(__FreeBSD__)
+	#define SPHERE_PLATFORM			"FreeBSD"
 #else
-	#define SPHERE_VER_ARCH			"32bit"
+	#define SPHERE_PLATFORM			"Unknown"
+#endif
+
+#if defined(_WIN64) || defined(x64)
+	#define SPHERE_VER_ARCH			"64-bit"
+#else
+	#define SPHERE_VER_ARCH			"32-bit"
 #endif
 
 #endif	// _INC_GRAYVER_H

--- a/src/common/version/GitRevision.h
+++ b/src/common/version/GitRevision.h
@@ -1,2 +1,2 @@
-#define __GITREVISION__ 1107
-#define __GITHASH__ "d760efab"
+#define __GITREVISION__ 1108
+#define __GITHASH__ "3b11cda4"

--- a/src/common/version/GitRevision.h
+++ b/src/common/version/GitRevision.h
@@ -1,0 +1,2 @@
+#define __GITREVISION__ 1106
+#define __GITHASH__ "e01bb6f3"

--- a/src/common/version/GitRevision.h
+++ b/src/common/version/GitRevision.h
@@ -1,2 +1,2 @@
-#define __GITREVISION__ 1106
-#define __GITHASH__ "e01bb6f3"
+#define __GITREVISION__ 1107
+#define __GITHASH__ "d760efab"

--- a/src/common/version/GitRevision.h
+++ b/src/common/version/GitRevision.h
@@ -1,2 +1,2 @@
-#define __GITREVISION__ 1108
-#define __GITHASH__ "3b11cda4"
+#define __GITREVISION__ 1109
+#define __GITHASH__ "57ab2307"

--- a/src/graysvr/CServRef.cpp
+++ b/src/graysvr/CServRef.cpp
@@ -19,7 +19,7 @@ CServerDef::CServerDef(LPCTSTR pszName, CSocketAddressIP dwIP) : m_ip(dwIP, SPHE
 	memset(m_dwStat, 0, sizeof(m_dwStat));	// THIS MUST BE FIRST
 	SetName(pszName);
 	m_timeCreate = CServTime::GetCurrentTime();
-	m_TimeZone = static_cast<signed char>(_timezone / (60 * 60));
+	m_TimeZone = static_cast<signed char>((size_t)_timezone / (60 * 60));
 }
 
 DWORD CServerDef::StatGet(SERV_STAT_TYPE i) const

--- a/src/graysvr/CServer.cpp
+++ b/src/graysvr/CServer.cpp
@@ -325,9 +325,9 @@ bool CServer::Load()
 		return false;
 
 #if defined(__GITREVISION__) && defined(__GITHASH__)
-	g_Log.Event(LOGL_EVENT, "%s (%s) by %s\nCompiled at %s (build %d / Git hash %s)\n\n", SPHERE_TITLE_VER, SPHERE_VER_ARCH, SPHERE_WEBSITE, g_szCompiledDate, __GITREVISION__, __GITHASH__);
+	g_Log.Event(LOGL_EVENT, "%s (%s %s) by %s\nCompiled at %s (build %d / Git hash %s)\n\n", SPHERE_TITLE_VER, SPHERE_VER_ARCH, SPHERE_PLATFORM, SPHERE_WEBSITE, g_szCompiledDate, __GITREVISION__, __GITHASH__);
 #else
-	g_Log.Event(LOGL_EVENT, "%s (%s) by %s\nCompiled at %s\n\n", SPHERE_TITLE_VER, SPHERE_VER_ARCH, SPHERE_WEBSITE, g_szCompiledDate);
+	g_Log.Event(LOGL_EVENT, "%s (%s %s) by %s\nCompiled at %s\n\n", SPHERE_TITLE_VER, SPHERE_VER_ARCH, SPHERE_PLATFORM, SPHERE_WEBSITE, g_szCompiledDate);
 #endif
 
 #ifdef _NIGHTLYBUILD

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -2,6 +2,10 @@
 #include "send.h"
 #include "receive.h"
 
+#ifdef __FreeBSD__
+	#include <sys/errno.h>
+#endif
+
 #if !defined(_WIN32) || defined(_LIBEV)
 	extern LinuxEv g_NetworkEvent;
 #endif

--- a/src/sphere/mutex.cpp
+++ b/src/sphere/mutex.cpp
@@ -12,7 +12,11 @@ SimpleMutex::SimpleMutex()
 	static_cast<void>(InitializeCriticalSectionAndSpinCount(&m_criticalSection, 0x80000020));
 #else
 	pthread_mutexattr_init(&m_criticalSectionAttr);
+#ifdef __FreeBSD__
+	pthread_mutexattr_settype(&m_criticalSectionAttr, PTHREAD_MUTEX_RECURSIVE);
+#else
 	pthread_mutexattr_settype(&m_criticalSectionAttr, PTHREAD_MUTEX_RECURSIVE_NP);
+#endif
 	pthread_mutex_init(&m_criticalSection, &m_criticalSectionAttr);
 #endif
 }
@@ -120,7 +124,11 @@ AutoResetEvent::AutoResetEvent()
 	m_handle = CreateEvent(NULL, FALSE, FALSE, NULL);
 #else
 	pthread_mutexattr_init(&m_criticalSectionAttr);
+#ifdef __FreeBSD__
+	pthread_mutexattr_settype(&m_criticalSectionAttr, PTHREAD_MUTEX_RECURSIVE);
+#else
 	pthread_mutexattr_settype(&m_criticalSectionAttr, PTHREAD_MUTEX_RECURSIVE_NP);
+#endif
 	pthread_mutex_init(&m_criticalSection, &m_criticalSectionAttr);
 
 	pthread_condattr_init(&m_conditionAttr);
@@ -203,7 +211,11 @@ ManualResetEvent::ManualResetEvent()
 #else
 	m_value = false;
 	pthread_mutexattr_init(&m_criticalSectionAttr);
+#ifdef __FreeBSD__
+	pthread_mutexattr_settype(&m_criticalSectionAttr, PTHREAD_MUTEX_RECURSIVE);
+#else
 	pthread_mutexattr_settype(&m_criticalSectionAttr, PTHREAD_MUTEX_RECURSIVE_NP);
+#endif
 	pthread_mutex_init(&m_criticalSection, &m_criticalSectionAttr);
 
 	pthread_condattr_init(&m_conditionAttr);

--- a/src/sphere/threads.cpp
+++ b/src/sphere/threads.cpp
@@ -7,7 +7,7 @@
 #include "threads.h"
 #ifndef _WIN32
 	#include <algorithm>
-	#ifndef _BSD
+	#ifdef __linux__
 		#include <sys/prctl.h>
 	#endif
 #endif
@@ -432,7 +432,9 @@ void AbstractThread::onStart()
 	// thread name must be 16 bytes, zero-padded if shorter
 	char name[16] = { '\0' };
 	strcpylen(name, m_name, COUNTOF(name));
+#ifdef __linux__
 	prctl(PR_SET_NAME, name, 0, 0, 0);
+#endif
 #endif
 }
 

--- a/src/sphere/threads.h
+++ b/src/sphere/threads.h
@@ -111,7 +111,11 @@ public:
 	virtual ~AbstractThread();
 
 private:
+#ifdef __FreeBSD__
+	pthread_t m_id;
+#else
 	unsigned int m_id;
+#endif
 	const char *m_name;
 	static int m_threadsAvailable;
 	spherethread_t m_handle;
@@ -128,7 +132,11 @@ private:
 	AbstractThread& operator=(const AbstractThread& other);
 
 public:
+#ifdef __FreeBSD__
+	unsigned int getId() const { return (unsigned int)(size_t)m_id; }
+#else
 	unsigned int getId() const { return m_id; }
+#endif
 	const char *getName() const { return m_name; }
 
 	bool isActive() const;


### PR DESCRIPTION
* Add FreeBSD makefile (`gmake -f makefile.fbsd`).
* Fix various Clang errors under FreeBSD (validated successful Linux and FreeBSD builds with gcc 9.3.0 and Clang 10.0.1).
* Fix `clock_gettime()` performance issue on FreeBSD (related to #263).
* Add SPHERE_PLATFORM to version information